### PR TITLE
Allow replacement to be a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ npm install mask-json
 Option        | Default value  | Description
 ------------- | -------------- | -----------------------------------------------------
 _ignoreCase_  | false          | Whether to ignore case sensitivity when matching keys
-_replacement_ | _--REDACTED--_ | The default value to replace
+_replacement_ | _--REDACTED--_ | The default value to replace, this can be either an explicit value or a function using current value as only parameter
 
 ### Returns
 
@@ -41,15 +41,31 @@ maskJson({ foo: 'bar', biz: { username: 'myusername', password: 'mypassword' } }
 // => { foo: 'bar', biz: { username: '--REDACTED--', password: '--REDACTED--' } }
 ```
 
-## Tests
+Works the same when "replacement" is not a static string, but a function to convert 
+the original value somehow, e.g. mask some parts of a credit card number or phone number
+like the original "1234-5678-9012" shall become "1234-****-9012".
+
+The replacement function is called with one parameter - the original value to replace.
 
 ```javascript
+// with replacement function
+var replaceFunc = function(value) { return value.toUpperCase() }; 
+var maskJson2 = require('mask-json')(blacklist, {replacement: replaceFunc});
+
+maskJson2({ foo: 'bar', biz: { username: 'myusername', password: 'mypassword' } });
+
+// => { foo: 'bar', biz: { username: 'MYUSERNAME', password: 'MYPASSWORD' } }
+```
+
+## Tests
+
+```shell script
 $ npm test
 ```
 
 ## Release
 
-```sh
+```shell script
 npm version [<new version> | major | minor | patch] -m "Release %s"
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5237,9 +5237,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "version": "npm run changelog && git add -A CHANGELOG.md"
   },
   "dependencies": {
-    "lodash": "^4.17.4"
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@uphold/github-changelog-generator": "^0.8.1",

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ module.exports = function maskJson(collection, {
     return cloneDeepWith(values, (value, key) => {
       // Strip matching keys.
       if (some(collection, item => ignoreCase ? toLower(key) === toLower(item) : key === item)) {
-        return replacement;
+        return (typeof replacement === 'function') ? replacement(value) : replacement;
       }
 
       // Allow cloneDeep to recurse into nested objects.

--- a/test/src/index.test.js
+++ b/test/src/index.test.js
@@ -30,7 +30,7 @@ describe('maskJson()', () => {
     });
   });
 
-  it('should accept a custom `replacement`', () => {
+  it('should accept a custom `replacement` value', () => {
     const object = {
       foo: {
         password: 'foobar',
@@ -42,6 +42,26 @@ describe('maskJson()', () => {
       foo: {
         password: '*****',
         secret: '*****'
+      }
+    });
+  });
+
+  it('should accept a custom `replacement` function', () => {
+    const object = {
+      foo: {
+        password: 'foobar',
+        secret: 'bizbaz'
+      }
+    };
+
+    function replacementFunc(value) {
+      return value.toUpperCase();
+    }
+
+    expect(maskJson(['password', 'secret'], { replacement: replacementFunc })(object)).toEqual({
+      foo: {
+        password: 'FOOBAR',
+        secret: 'BIZBAZ'
       }
     });
   });


### PR DESCRIPTION
Current implementation allows setting on specific value one for value redaction.
This PR allows setting a function too, to allow replacing fields based on their value.

This is helpful for replacing some personal data not completely private like phone numbers, email addresses or credit card numbers where a partial value is helpful to check everything was correctly set in the original object.

As a second thing the minimum  lodash version required was updated to the current one to help improve security as older version contained multiple severe security vulnerabilities. Due to this other projects not actively maintained will get this security updates too. This update is done by many of other projects too to improve overall security of nodejs eco system.
(https://nvd.nist.gov/vuln/search/results?form_type=Basic&results_type=overview&query=lodash&queryType=phrase&search_type=all)